### PR TITLE
Add CI workflow and enforce Prettier formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      # Public Sanity project identifiers — same values used in astro.config.mjs
+      # and embedded in the production JS bundle. Not secrets.
+      PUBLIC_SANITY_STUDIO_PROJECT_ID: 2nhyst6p
+      PUBLIC_SANITY_STUDIO_DATASET: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Type check
+        run: npx astro check
+
+      - name: Build
+        run: npx astro build

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,14 @@
 {
   "semi": false,
   "singleQuote": true,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "plugins": ["prettier-plugin-astro"],
+  "overrides": [
+    {
+      "files": "*.astro",
+      "options": {
+        "parser": "astro"
+      }
+    }
+  ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@playwright/test": "^1.57.0",
         "playwright": "^1.57.0",
         "prettier": "^3.6.2",
+        "prettier-plugin-astro": "^0.14.1",
         "typescript": "^5.9.3"
       }
     },
@@ -21993,6 +21994,22 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-plugin-astro": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-astro/-/prettier-plugin-astro-0.14.1.tgz",
+      "integrity": "sha512-RiBETaaP9veVstE4vUwSIcdATj6dKmXljouXc/DDNwBSPTp8FRkLGDSGFClKsAFeeg+13SB0Z1JZvbD76bigJw==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@astrojs/compiler": "^2.9.1",
+        "prettier": "^3.0.0",
+        "sass-formatter": "^0.7.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
@@ -23234,6 +23251,13 @@
         "rxjs": "7.x"
       }
     },
+    "node_modules/s.color": {
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/s.color/-/s.color-0.0.15.tgz",
+      "integrity": "sha512-AUNrbEUHeKY8XsYr/DYpl+qk5+aM+DChopnWOPEzn8YKzOhv4l2zH6LzZms3tOZP3wwdOyc0RmTciyi46HLIuA==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -24115,6 +24139,16 @@
         }
       }
     },
+    "node_modules/sass-formatter": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/sass-formatter/-/sass-formatter-0.7.9.tgz",
+      "integrity": "sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "suf-log": "^2.5.3"
+      }
+    },
     "node_modules/sax": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
@@ -24799,6 +24833,16 @@
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
       "license": "MIT"
+    },
+    "node_modules/suf-log": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/suf-log/-/suf-log-2.5.3.tgz",
+      "integrity": "sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "s.color": "0.0.15"
+      }
     },
     "node_modules/supports-color": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "astro preview",
     "astro": "astro",
     "sync": "node scripts/sync-from-sanity.ts",
-    "format": "prettier --write \"src/**/*.{js,ts,astro,tsx}\""
+    "format": "prettier --write \"src/**/*.{js,ts,astro,tsx}\"",
+    "format:check": "prettier --check \"src/**/*.{js,ts,astro,tsx}\""
   },
   "dependencies": {
     "@astrojs/check": "^0.9.6",
@@ -34,6 +35,7 @@
     "@playwright/test": "^1.57.0",
     "playwright": "^1.57.0",
     "prettier": "^3.6.2",
+    "prettier-plugin-astro": "^0.14.1",
     "typescript": "^5.9.3"
   }
 }

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -1,25 +1,27 @@
 ---
 interface Props {
-  className?: string;
-  href?: string;
-  type?: 'button' | 'submit' | 'reset';
-  [key: string]: any;
+  className?: string
+  href?: string
+  type?: 'button' | 'submit' | 'reset'
+  [key: string]: any
 }
 
-const { className, href, type = 'button', ...passThroughProps } = Astro.props;
-const classes = className ? `button ${className}` : 'button';
-const Element = href ? 'a' : 'button';
+const { className, href, type = 'button', ...passThroughProps } = Astro.props
+const classes = className ? `button ${className}` : 'button'
+const Element = href ? 'a' : 'button'
 ---
 
-{Element === 'a' ? (
-  <a class={classes} href={href} {...passThroughProps}>
-    <slot />
-  </a>
-) : (
-  <button class={classes} type={type} {...passThroughProps}>
-    <slot />
-  </button>
-)}
+{
+  Element === 'a' ? (
+    <a class={classes} href={href} {...passThroughProps}>
+      <slot />
+    </a>
+  ) : (
+    <button class={classes} type={type} {...passThroughProps}>
+      <slot />
+    </button>
+  )
+}
 
 <style>
   .button {

--- a/src/components/GoatBio.astro
+++ b/src/components/GoatBio.astro
@@ -1,38 +1,38 @@
 ---
-import type { ImageMetadata } from 'astro';
-import { Image } from 'astro:assets';
-import { format } from 'date-fns';
-import SectionTitle from './SectionTitle.astro';
+import type { ImageMetadata } from 'astro'
+import { Image } from 'astro:assets'
+import { format } from 'date-fns'
+import SectionTitle from './SectionTitle.astro'
 
 interface Parent {
-  name: string;
-  link?: string;
+  name: string
+  link?: string
 }
 
 interface GoatParent {
-  name: string;
-  link: string;
-  sire?: Parent;
-  dam?: Parent;
+  name: string
+  link: string
+  sire?: Parent
+  dam?: Parent
 }
 
 interface GoatImage {
-  image?: ImageMetadata;
-  src?: string; // For Sanity CDN URLs
-  alt: string;
+  image?: ImageMetadata
+  src?: string // For Sanity CDN URLs
+  alt: string
 }
 
 interface Props {
-  images?: GoatImage[];
-  name: string;
-  slug: string;
-  adgaPedigree: string;
-  date: string;
-  sire: GoatParent;
-  dam: GoatParent;
-  copy?: string[];
-  showCopy?: boolean;
-  withTitle?: boolean;
+  images?: GoatImage[]
+  name: string
+  slug: string
+  adgaPedigree: string
+  date: string
+  sire: GoatParent
+  dam: GoatParent
+  copy?: string[]
+  showCopy?: boolean
+  withTitle?: boolean
 }
 
 const {
@@ -45,43 +45,46 @@ const {
   dam,
   copy = [],
   showCopy = false,
-  withTitle = true
-} = Astro.props;
+  withTitle = true,
+} = Astro.props
 
-const birthDate = format(new Date(date), 'M/d/yyyy');
+const birthDate = format(new Date(date), 'M/d/yyyy')
 
 // First image is the profile image
-const profileImage = images[0];
-const additionalImages = images.slice(1);
+const profileImage = images[0]
+const additionalImages = images.slice(1)
 ---
 
 <div class="goat">
-  {profileImage && (
-    profileImage.src ? (
-      <img
-        src={`${profileImage.src}?w=380&auto=format`}
-        srcset={`${profileImage.src}?w=380&auto=format 1x, ${profileImage.src}?w=760&auto=format 2x`}
-        alt={profileImage.alt}
-        class="photo"
-        width="380"
-        loading="lazy"
-      />
-    ) : profileImage.image ? (
-      <Image
-        src={profileImage.image}
-        alt={profileImage.alt}
-        class="photo"
-        width={380}
-      />
-    ) : null
-  )}
+  {
+    profileImage &&
+      (profileImage.src ? (
+        <img
+          src={`${profileImage.src}?w=380&auto=format`}
+          srcset={`${profileImage.src}?w=380&auto=format 1x, ${profileImage.src}?w=760&auto=format 2x`}
+          alt={profileImage.alt}
+          class="photo"
+          width="380"
+          loading="lazy"
+        />
+      ) : profileImage.image ? (
+        <Image
+          src={profileImage.image}
+          alt={profileImage.alt}
+          class="photo"
+          width={380}
+        />
+      ) : null)
+  }
 
   <header class="content">
-    {withTitle && (
-      <SectionTitle>
-        <a href={`/goats/${slug}`}>{name}</a>
-      </SectionTitle>
-    )}
+    {
+      withTitle && (
+        <SectionTitle>
+          <a href={`/goats/${slug}`}>{name}</a>
+        </SectionTitle>
+      )
+    }
     <span>Born {birthDate}</span><br />
     <a href={adgaPedigree}>ADGA Pedigree</a>
 
@@ -89,65 +92,84 @@ const additionalImages = images.slice(1);
       <li class="listItem">
         <strong>Sire</strong>: <a href={sire.link}>{sire.name}</a>
       </li>
-      {sire.sire && (
-        <li class="listItem">
-          <strong>SS</strong>: {sire.sire.link ? (
-            <a href={sire.sire.link}>{sire.sire.name}</a>
-          ) : sire.sire.name}
-        </li>
-      )}
-      {sire.dam && (
-        <li class="listItem">
-          <strong>SD</strong>: {sire.dam.link ? (
-            <a href={sire.dam.link}>{sire.dam.name}</a>
-          ) : sire.dam.name}
-        </li>
-      )}
+      {
+        sire.sire && (
+          <li class="listItem">
+            <strong>SS</strong>:{' '}
+            {sire.sire.link ? (
+              <a href={sire.sire.link}>{sire.sire.name}</a>
+            ) : (
+              sire.sire.name
+            )}
+          </li>
+        )
+      }
+      {
+        sire.dam && (
+          <li class="listItem">
+            <strong>SD</strong>:{' '}
+            {sire.dam.link ? (
+              <a href={sire.dam.link}>{sire.dam.name}</a>
+            ) : (
+              sire.dam.name
+            )}
+          </li>
+        )
+      }
       <li class="listItem">
         <strong>Dam</strong>: <a href={dam.link}>{dam.name}</a>
       </li>
-      {dam.sire && (
-        <li class="listItem">
-          <strong>DS</strong>: {dam.sire.link ? (
-            <a href={dam.sire.link}>{dam.sire.name}</a>
-          ) : dam.sire.name}
-        </li>
-      )}
-      {dam.dam && (
-        <li class="listItem">
-          <strong>DD</strong>: {dam.dam.link ? (
-            <a href={dam.dam.link}>{dam.dam.name}</a>
-          ) : dam.dam.name}
-        </li>
-      )}
+      {
+        dam.sire && (
+          <li class="listItem">
+            <strong>DS</strong>:{' '}
+            {dam.sire.link ? (
+              <a href={dam.sire.link}>{dam.sire.name}</a>
+            ) : (
+              dam.sire.name
+            )}
+          </li>
+        )
+      }
+      {
+        dam.dam && (
+          <li class="listItem">
+            <strong>DD</strong>:{' '}
+            {dam.dam.link ? (
+              <a href={dam.dam.link}>{dam.dam.name}</a>
+            ) : (
+              dam.dam.name
+            )}
+          </li>
+        )
+      }
     </ul>
   </header>
 
-  {showCopy && copy.map((content) => (
-    <p class="bodyContent" set:html={content} />
-  ))}
+  {
+    showCopy &&
+      copy.map((content) => <p class="bodyContent" set:html={content} />)
+  }
   <!-- Note: set:html is used here for content from trusted CMS sources only.
        Content is pre-processed in getStaticPaths and should never include user input. -->
 
-  {showCopy && additionalImages.map(({ image, src, alt }) => (
-    src ? (
-      <img
-        src={`${src}?w=380&auto=format`}
-        srcset={`${src}?w=380&auto=format 1x, ${src}?w=760&auto=format 2x`}
-        alt={alt}
-        class="photo"
-        width="380"
-        loading="lazy"
-      />
-    ) : image ? (
-      <Image
-        src={image}
-        alt={alt}
-        class="photo"
-        width={380}
-      />
-    ) : null
-  ))}
+  {
+    showCopy &&
+      additionalImages.map(({ image, src, alt }) =>
+        src ? (
+          <img
+            src={`${src}?w=380&auto=format`}
+            srcset={`${src}?w=380&auto=format 1x, ${src}?w=760&auto=format 2x`}
+            alt={alt}
+            class="photo"
+            width="380"
+            loading="lazy"
+          />
+        ) : image ? (
+          <Image src={image} alt={alt} class="photo" width={380} />
+        ) : null
+      )
+  }
 </div>
 
 <style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,21 +1,23 @@
 ---
 interface Props {
-  siteTitle: string;
+  siteTitle: string
 }
 
-const { siteTitle } = Astro.props;
-const currentPath = Astro.url.pathname;
+const { siteTitle } = Astro.props
+const currentPath = Astro.url.pathname
 
 // Helper function to check if link is active
 const isActive = (path: string) => {
   if (path === '/goats') {
-    return currentPath.startsWith('/goats') && !currentPath.startsWith('/kidding');
+    return (
+      currentPath.startsWith('/goats') && !currentPath.startsWith('/kidding')
+    )
   }
   if (path === '/kidding-schedule') {
-    return currentPath.startsWith('/kidding-schedule');
+    return currentPath.startsWith('/kidding-schedule')
   }
-  return false;
-};
+  return false
+}
 ---
 
 <header class="header">
@@ -34,19 +36,16 @@ const isActive = (path: string) => {
       </li>
       <li class="navItem">
         <a
-          class={isActive('/kidding-schedule') ? 'activeNavLink navLink' : 'navLink'}
+          class={isActive('/kidding-schedule')
+            ? 'activeNavLink navLink'
+            : 'navLink'}
           href="/kidding-schedule/"
         >
           Kidding Schedule
         </a>
       </li>
       <li class="navItem">
-        <a
-          class="navLink"
-          href="/#contact"
-        >
-          Contact Us
-        </a>
+        <a class="navLink" href="/#contact"> Contact Us </a>
       </li>
     </ul>
   </nav>

--- a/src/components/Info.astro
+++ b/src/components/Info.astro
@@ -1,11 +1,11 @@
 ---
-import SectionTitle from './SectionTitle.astro';
+import SectionTitle from './SectionTitle.astro'
 
 interface Props {
-  title: string;
+  title: string
 }
 
-const { title } = Astro.props;
+const { title } = Astro.props
 ---
 
 <div class="heading">
@@ -17,7 +17,7 @@ const { title } = Astro.props;
   .heading {
     grid-column: 1 / -1;
     color: var(--color-darker-purple);
-    background-color: rgba(255, 255, 255, .3);
+    background-color: rgba(255, 255, 255, 0.3);
     padding: 0 1em;
   }
 

--- a/src/components/KiddingSchedule.astro
+++ b/src/components/KiddingSchedule.astro
@@ -1,167 +1,183 @@
 ---
-import type { ImageMetadata } from 'astro';
-import { Image } from 'astro:assets';
-import { format } from 'date-fns';
-import SectionContainer from './SectionContainer.astro';
-import SectionTitle from './SectionTitle.astro';
+import type { ImageMetadata } from 'astro'
+import { Image } from 'astro:assets'
+import { format } from 'date-fns'
+import SectionContainer from './SectionContainer.astro'
+import SectionTitle from './SectionTitle.astro'
 
 interface GoatImage {
-  image?: ImageMetadata; // For local images
-  src?: string; // For Sanity CDN URLs
-  alt: string;
+  image?: ImageMetadata // For local images
+  src?: string // For Sanity CDN URLs
+  alt: string
 }
 
 interface Props {
   goats: Array<{
-    id: string;
+    id: string
     data: {
-      name: string;
-      aka: string;
-      slug: string;
-      kiddingDate?: string;
+      name: string
+      aka: string
+      slug: string
+      kiddingDate?: string
       mate?: {
-        name: string;
-        slug: string;
-        link: string;
-      };
-      pedigree?: string;
-      notes?: string[];
-      prices?: string[];
-    };
-    profileImage?: GoatImage | ImageMetadata;
-    mateImage?: GoatImage | ImageMetadata;
-  }>;
+        name: string
+        slug: string
+        link: string
+      }
+      pedigree?: string
+      notes?: string[]
+      prices?: string[]
+    }
+    profileImage?: GoatImage | ImageMetadata
+    mateImage?: GoatImage | ImageMetadata
+  }>
 }
 
-const { goats } = Astro.props;
+const { goats } = Astro.props
 
 // Filter goats that have kidding dates
-const kiddingGoats = goats.filter(goat => goat.data.kiddingDate);
+const kiddingGoats = goats.filter((goat) => goat.data.kiddingDate)
 ---
 
 <SectionContainer id="kidding-schedule" className="kiddingScheduleContainer">
-  <SectionTitle className='sectionTitle'>2026 Kidding Schedule</SectionTitle>
+  <SectionTitle className="sectionTitle">2026 Kidding Schedule</SectionTitle>
   <div class="tableContainer">
     <table>
       <thead>
         <tr>
           <td class="tableHeading">Dam</td>
           <td class="tableHeading">Sire</td>
-          <td class="tableHeading dueDateColumn">
-            Due Date
-          </td>
+          <td class="tableHeading dueDateColumn"> Due Date </td>
           <td class="tableHeading">ADGA Pedigree</td>
           <td class="tableHeading">Notes</td>
           <td class="tableHeading">Fee</td>
         </tr>
       </thead>
       <tbody>
-        {kiddingGoats.map((goat) => (
-          <tr>
-            <td>
-              <figure>
-                {goat.profileImage && (
-                  typeof goat.profileImage === 'object' && 'src' in goat.profileImage && goat.profileImage.src && 'alt' in goat.profileImage ? (
-                    <img
-                      src={`${goat.profileImage.src}?w=150&auto=format`}
-                      srcset={`${goat.profileImage.src}?w=150&auto=format 1x, ${goat.profileImage.src}?w=300&auto=format 2x`}
-                      alt={goat.profileImage.alt}
-                      width="150"
-                      height="150"
-                      class="goatImage"
-                      loading="lazy"
-                    />
-                  ) : typeof goat.profileImage === 'object' && 'width' in goat.profileImage ? (
-                    <Image
-                      src={goat.profileImage}
-                      alt={goat.data.name}
-                      width={150}
-                      height={150}
-                      class="goatImage"
-                    />
-                  ) : null
-                )}
-                <figcaption>
-                  <a href={`/goats/${goat.data.slug}`}>
-                    {goat.data.name.replace('(pending)', '').trim()}
-                  </a>
-                </figcaption>
-              </figure>
-            </td>
-            <td>
-              {goat.data.mate?.name ? (
+        {
+          kiddingGoats.map((goat) => (
+            <tr>
+              <td>
                 <figure>
-                  {goat.mateImage && (
-                    typeof goat.mateImage === 'object' && 'src' in goat.mateImage && goat.mateImage.src && 'alt' in goat.mateImage ? (
+                  {goat.profileImage &&
+                    (typeof goat.profileImage === 'object' &&
+                    'src' in goat.profileImage &&
+                    goat.profileImage.src &&
+                    'alt' in goat.profileImage ? (
                       <img
-                        src={`${goat.mateImage.src}?w=150&auto=format`}
-                        srcset={`${goat.mateImage.src}?w=150&auto=format 1x, ${goat.mateImage.src}?w=300&auto=format 2x`}
-                        alt={goat.mateImage.alt}
+                        src={`${goat.profileImage.src}?w=150&auto=format`}
+                        srcset={`${goat.profileImage.src}?w=150&auto=format 1x, ${goat.profileImage.src}?w=300&auto=format 2x`}
+                        alt={goat.profileImage.alt}
                         width="150"
                         height="150"
                         class="goatImage"
                         loading="lazy"
                       />
-                    ) : typeof goat.mateImage === 'object' && 'width' in goat.mateImage ? (
+                    ) : typeof goat.profileImage === 'object' &&
+                      'width' in goat.profileImage ? (
                       <Image
-                        src={goat.mateImage}
-                        alt={goat.data.mate.name}
+                        src={goat.profileImage}
+                        alt={goat.data.name}
                         width={150}
                         height={150}
                         class="goatImage"
                       />
-                    ) : null
-                  )}
+                    ) : null)}
                   <figcaption>
-                    <a href={goat.data.mate.link} target="_blank" rel="noopener noreferrer">
-                      {goat.data.mate.name}
+                    <a href={`/goats/${goat.data.slug}`}>
+                      {goat.data.name.replace('(pending)', '').trim()}
                     </a>
                   </figcaption>
                 </figure>
-              ) : "TBD"}
-            </td>
-            <td>
-              {goat.data.kiddingDate === 'TBD'
-                ? goat.data.kiddingDate
-                : goat.data.kiddingDate && format(new Date(goat.data.kiddingDate), 'MMM d, yyyy')
-              }
-              {goat.data.kiddingDate === 'TBD' && (
-                <>
-                  <br />
-                  <small>Likely late May</small>
-                </>
-              )}
-            </td>
-            <td>
-              {goat.data.pedigree && (
-                <a href={goat.data.pedigree} target="_blank" rel="noopener noreferrer">
-                  ADGA Planned Pedigree
-                </a>
-              )}
-            </td>
-            <td>
-              {goat.data.notes && goat.data.notes.length > 0 && (
-                goat.data.notes.map((note) => (
-                  <p class="note">{note}</p>
-                ))
-              )}
-            </td>
-            <td>
-              {goat.data.prices && goat.data.prices.length > 0 && (
-                goat.data.prices.map((price) => (
-                  <p class="note">{price}</p>
-                ))
-              )}
-            </td>
-          </tr>
-        ))}
+              </td>
+              <td>
+                {goat.data.mate?.name ? (
+                  <figure>
+                    {goat.mateImage &&
+                      (typeof goat.mateImage === 'object' &&
+                      'src' in goat.mateImage &&
+                      goat.mateImage.src &&
+                      'alt' in goat.mateImage ? (
+                        <img
+                          src={`${goat.mateImage.src}?w=150&auto=format`}
+                          srcset={`${goat.mateImage.src}?w=150&auto=format 1x, ${goat.mateImage.src}?w=300&auto=format 2x`}
+                          alt={goat.mateImage.alt}
+                          width="150"
+                          height="150"
+                          class="goatImage"
+                          loading="lazy"
+                        />
+                      ) : typeof goat.mateImage === 'object' &&
+                        'width' in goat.mateImage ? (
+                        <Image
+                          src={goat.mateImage}
+                          alt={goat.data.mate.name}
+                          width={150}
+                          height={150}
+                          class="goatImage"
+                        />
+                      ) : null)}
+                    <figcaption>
+                      <a
+                        href={goat.data.mate.link}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {goat.data.mate.name}
+                      </a>
+                    </figcaption>
+                  </figure>
+                ) : (
+                  'TBD'
+                )}
+              </td>
+              <td>
+                {goat.data.kiddingDate === 'TBD'
+                  ? goat.data.kiddingDate
+                  : goat.data.kiddingDate &&
+                    format(new Date(goat.data.kiddingDate), 'MMM d, yyyy')}
+                {goat.data.kiddingDate === 'TBD' && (
+                  <>
+                    <br />
+                    <small>Likely late May</small>
+                  </>
+                )}
+              </td>
+              <td>
+                {goat.data.pedigree && (
+                  <a
+                    href={goat.data.pedigree}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    ADGA Planned Pedigree
+                  </a>
+                )}
+              </td>
+              <td>
+                {goat.data.notes &&
+                  goat.data.notes.length > 0 &&
+                  goat.data.notes.map((note) => <p class="note">{note}</p>)}
+              </td>
+              <td>
+                {goat.data.prices &&
+                  goat.data.prices.length > 0 &&
+                  goat.data.prices.map((price) => <p class="note">{price}</p>)}
+              </td>
+            </tr>
+          ))
+        }
       </tbody>
     </table>
   </div>
   <small class="attribution">
-    Till-Riv BNS Smooth Edition *B, and Diji Farm DJ Shaboozie *B
-    appear courtesy of{' '}
-    <a href="https://www.dijifarm.com" target="_blank" rel="noopener noreferrer">
+    Till-Riv BNS Smooth Edition *B, and Diji Farm DJ Shaboozie *B appear
+    courtesy of{' '}
+    <a
+      href="https://www.dijifarm.com"
+      target="_blank"
+      rel="noopener noreferrer"
+    >
       Diji Farm
     </a>
     .

--- a/src/components/SectionContainer.astro
+++ b/src/components/SectionContainer.astro
@@ -1,11 +1,11 @@
 ---
 interface Props {
-  className?: string;
-  id?: string;
-  [key: string]: any;
+  className?: string
+  id?: string
+  [key: string]: any
 }
 
-const { className = '', ...rest } = Astro.props;
+const { className = '', ...rest } = Astro.props
 ---
 
 <section class={`container ${className}`} {...rest}>
@@ -14,7 +14,7 @@ const { className = '', ...rest } = Astro.props;
 
 <style>
   .container {
-    background-color: rgba(76, 40, 81, .3);
+    background-color: rgba(76, 40, 81, 0.3);
     background-position: center center;
     background-repeat: no-repeat;
     background-size: cover;

--- a/src/components/SectionTitle.astro
+++ b/src/components/SectionTitle.astro
@@ -1,10 +1,10 @@
 ---
 type Props = {
-  className?: string;
+  className?: string
 }
 
-const { className } = Astro.props;
-const classes = className ? `title ${className}` : 'title';
+const { className } = Astro.props
+const classes = className ? `title ${className}` : 'title'
 ---
 
 <h3 class={classes}>
@@ -23,7 +23,7 @@ const classes = className ? `title ${className}` : 'title';
   }
 
   .sectionTitle {
-    padding: .5rem 0;
+    padding: 0.5rem 0;
     text-align: center;
   }
 </style>

--- a/src/components/sections/Contact.astro
+++ b/src/components/sections/Contact.astro
@@ -1,6 +1,6 @@
 ---
-import SectionContainer from '../SectionContainer.astro';
-import Button from '../Button.astro';
+import SectionContainer from '../SectionContainer.astro'
+import Button from '../Button.astro'
 ---
 
 <SectionContainer id="contact" className="container">
@@ -42,12 +42,9 @@ import Button from '../Button.astro';
       class="textarea"
       placeholder="Adopt a goat!"
       required
-      aria-label="Message"
-    />
+      aria-label="Message"></textarea>
 
-    <Button type="submit">
-      Contact Us
-    </Button>
+    <Button type="submit"> Contact Us </Button>
   </form>
 
   <!-- TODO: make dialog modal better -->
@@ -57,61 +54,68 @@ import Button from '../Button.astro';
   </dialog>
 
   <dialog id="error-dialog" class="modal">
-    <p>Sorry, there was an error submitting your message. Please try again or email us directly.</p>
+    <p>
+      Sorry, there was an error submitting your message. Please try again or
+      email us directly.
+    </p>
     <Button id="close-error-dialog">Close</Button>
   </dialog>
 </SectionContainer>
 
 <script>
-  const form = document.querySelector('form[name="contact"]') as HTMLFormElement;
-  const successDialog = document.getElementById('success-dialog') as HTMLDialogElement;
-  const errorDialog = document.getElementById('error-dialog') as HTMLDialogElement;
-  const closeBtn = document.getElementById('close-dialog');
-  const closeErrorBtn = document.getElementById('close-error-dialog');
+  const form = document.querySelector('form[name="contact"]') as HTMLFormElement
+  const successDialog = document.getElementById(
+    'success-dialog'
+  ) as HTMLDialogElement
+  const errorDialog = document.getElementById(
+    'error-dialog'
+  ) as HTMLDialogElement
+  const closeBtn = document.getElementById('close-dialog')
+  const closeErrorBtn = document.getElementById('close-error-dialog')
 
   if (form && successDialog && errorDialog && closeBtn && closeErrorBtn) {
     form.addEventListener('submit', async (e) => {
-      e.preventDefault();
+      e.preventDefault()
 
-      const formData = new FormData(form);
-      const params = new URLSearchParams();
+      const formData = new FormData(form)
+      const params = new URLSearchParams()
       formData.forEach((value, key) => {
-        params.append(key, value.toString());
-      });
-      const body = params.toString();
+        params.append(key, value.toString())
+      })
+      const body = params.toString()
 
       try {
         const response = await fetch('/', {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: body
-        });
+          body: body,
+        })
 
         if (response.ok) {
-          successDialog.showModal();
-          form.reset();
+          successDialog.showModal()
+          form.reset()
         } else {
-          throw new Error('Form submission failed');
+          throw new Error('Form submission failed')
         }
       } catch (error) {
-        errorDialog.showModal();
+        errorDialog.showModal()
       }
-    });
+    })
 
-    closeBtn.addEventListener('click', () => successDialog.close());
-    closeErrorBtn.addEventListener('click', () => errorDialog.close());
+    closeBtn.addEventListener('click', () => successDialog.close())
+    closeErrorBtn.addEventListener('click', () => errorDialog.close())
 
     successDialog.addEventListener('click', (e) => {
       if (e.target === successDialog) {
-        successDialog.close();
+        successDialog.close()
       }
-    });
+    })
 
     errorDialog.addEventListener('click', (e) => {
       if (e.target === errorDialog) {
-        errorDialog.close();
+        errorDialog.close()
       }
-    });
+    })
   }
 </script>
 
@@ -165,7 +169,7 @@ import Button from '../Button.astro';
     display: grid;
     z-index: 10000;
     position: fixed;
-    background-color: rgba(0, 0, 0, .75);
+    background-color: rgba(0, 0, 0, 0.75);
     height: 100vh;
     width: 100vw;
     top: 0;

--- a/src/components/sections/Deliveries.astro
+++ b/src/components/sections/Deliveries.astro
@@ -1,7 +1,7 @@
 ---
-import SectionContainer from '../SectionContainer.astro';
-import SectionTitle from '../SectionTitle.astro';
-import Button from '../Button.astro';
+import SectionContainer from '../SectionContainer.astro'
+import SectionTitle from '../SectionTitle.astro'
+import Button from '../Button.astro'
 ---
 
 <SectionContainer id="deliveries" className="container">
@@ -43,11 +43,7 @@ import Button from '../Button.astro';
       </label>
 
       <label class="checkbox">
-        <input
-          type="checkbox"
-          name="deliveryOptions"
-          value="Honey"
-        />
+        <input type="checkbox" name="deliveryOptions" value="Honey" />
         <span>Honey</span>
       </label>
 
@@ -55,17 +51,13 @@ import Button from '../Button.astro';
         <input
           type="checkbox"
           name="deliveryOptions"
-          value="Seasonal fruit &amp; veggies"
+          value="Seasonal fruit & veggies"
         />
         <span>Seasonal fruit &amp; veggies</span>
       </label>
 
       <label class="checkbox">
-        <input
-          type="checkbox"
-          name="deliveryOptions"
-          value="Other"
-        />
+        <input type="checkbox" name="deliveryOptions" value="Other" />
         <span>Other</span>
       </label>
     </fieldset>
@@ -92,79 +84,87 @@ import Button from '../Button.astro';
       name="message"
       class="textarea"
       placeholder="Anything else?"
-      aria-label="Anything else?"
-    />
+      aria-label="Anything else?"></textarea>
 
-    <Button type="submit">
-      Send
-    </Button>
+    <Button type="submit"> Send </Button>
   </form>
 
   <dialog id="success-dialog" class="modal">
     <div class="modal-content">
-      <p>Thanks for your interest! We'll be in touch shortly about deliveries.</p>
+      <p>
+        Thanks for your interest! We'll be in touch shortly about deliveries.
+      </p>
       <Button id="close-dialog">Close</Button>
     </div>
   </dialog>
 
   <dialog id="error-dialog" class="modal">
     <div class="modal-content">
-      <p>Sorry, there was an error submitting your request. Please try again or email us directly.</p>
+      <p>
+        Sorry, there was an error submitting your request. Please try again or
+        email us directly.
+      </p>
       <Button id="close-error-dialog">Close</Button>
     </div>
   </dialog>
 </SectionContainer>
 
 <script>
-  const form = document.querySelector('form[name="deliveries"]') as HTMLFormElement;
-  const successDialog = document.getElementById('success-dialog') as HTMLDialogElement;
-  const errorDialog = document.getElementById('error-dialog') as HTMLDialogElement;
-  const closeBtn = document.getElementById('close-dialog');
-  const closeErrorBtn = document.getElementById('close-error-dialog');
+  const form = document.querySelector(
+    'form[name="deliveries"]'
+  ) as HTMLFormElement
+  const successDialog = document.getElementById(
+    'success-dialog'
+  ) as HTMLDialogElement
+  const errorDialog = document.getElementById(
+    'error-dialog'
+  ) as HTMLDialogElement
+  const closeBtn = document.getElementById('close-dialog')
+  const closeErrorBtn = document.getElementById('close-error-dialog')
 
   if (form && successDialog && errorDialog && closeBtn && closeErrorBtn) {
     form.addEventListener('submit', async (e) => {
-      e.preventDefault();
+      e.preventDefault()
 
-      const formData = new FormData(form);
-      const params = new URLSearchParams();
+      const formData = new FormData(form)
+      const params = new URLSearchParams()
       formData.forEach((value, key) => {
-        params.append(key, value.toString());
-      });
-      const body = params.toString();
+        params.append(key, value.toString())
+      })
+      const body = params.toString()
 
       try {
         const response = await fetch('/', {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: body
-        });
+          body: body,
+        })
 
         if (response.ok) {
-          successDialog.showModal();
-          form.reset();
+          successDialog.showModal()
+          form.reset()
         } else {
-          throw new Error('Form submission failed');
+          throw new Error('Form submission failed')
         }
       } catch (error) {
-        errorDialog.showModal();
+        errorDialog.showModal()
       }
-    });
+    })
 
-    closeBtn.addEventListener('click', () => successDialog.close());
-    closeErrorBtn.addEventListener('click', () => errorDialog.close());
+    closeBtn.addEventListener('click', () => successDialog.close())
+    closeErrorBtn.addEventListener('click', () => errorDialog.close())
 
     successDialog.addEventListener('click', (e) => {
       if (e.target === successDialog) {
-        successDialog.close();
+        successDialog.close()
       }
-    });
+    })
 
     errorDialog.addEventListener('click', (e) => {
       if (e.target === errorDialog) {
-        errorDialog.close();
+        errorDialog.close()
       }
-    });
+    })
   }
 </script>
 

--- a/src/components/sections/Gallery.astro
+++ b/src/components/sections/Gallery.astro
@@ -1,30 +1,36 @@
 ---
-import { Image } from 'astro:assets';
-import Button from '../Button.astro';
-import SectionContainer from '../SectionContainer.astro';
-import Info from '../Info.astro';
-import { sanityClient } from '../../lib/sanity';
-import { homePageQuery } from '../../lib/queries';
-import { portableTextToHtml } from '../../lib/portableText';
-import type { HomePage } from '../../types/sanity';
+import { Image } from 'astro:assets'
+import Button from '../Button.astro'
+import SectionContainer from '../SectionContainer.astro'
+import Info from '../Info.astro'
+import { sanityClient } from '../../lib/sanity'
+import { homePageQuery } from '../../lib/queries'
+import { portableTextToHtml } from '../../lib/portableText'
+import type { HomePage } from '../../types/sanity'
 
-import bia from '../../images/image-gallery/bia.jpg';
-import garden from '../../images/image-gallery/garden.jpg';
-import bee from '../../images/image-gallery/bee.jpg';
-import flock from '../../images/image-gallery/flock.jpg';
-import goats from '../../images/image-gallery/goats.jpg';
-import wings from '../../images/image-gallery/wings.jpg';
-import cheese from '../../images/image-gallery/cheese.jpg';
-import emma from '../../images/image-gallery/emma.jpg';
-import laila from '../../images/image-gallery/laila.jpg';
-import family from '../../images/family.jpg';
+import bia from '../../images/image-gallery/bia.jpg'
+import garden from '../../images/image-gallery/garden.jpg'
+import bee from '../../images/image-gallery/bee.jpg'
+import flock from '../../images/image-gallery/flock.jpg'
+import goats from '../../images/image-gallery/goats.jpg'
+import wings from '../../images/image-gallery/wings.jpg'
+import cheese from '../../images/image-gallery/cheese.jpg'
+import emma from '../../images/image-gallery/emma.jpg'
+import laila from '../../images/image-gallery/laila.jpg'
+import family from '../../images/family.jpg'
 
-const homePage = await sanityClient.fetch<HomePage>(homePageQuery);
+const homePage = await sanityClient.fetch<HomePage>(homePageQuery)
 ---
 
 <SectionContainer id="gallery" className="galleryContainer">
   <Info title={homePage?.welcomeTitle || 'Welcome to our farm'}>
-    <Image src={family} alt="Family photo" class="mainPhoto" widths={[300, 600]} sizes="(max-width: 300px) 100vw, 300px" />
+    <Image
+      src={family}
+      alt="Family photo"
+      class="mainPhoto"
+      widths={[300, 600]}
+      sizes="(max-width: 300px) 100vw, 300px"
+    />
     <Fragment set:html={portableTextToHtml(homePage?.welcomeText || [])} />
   </Info>
   <Image
@@ -41,11 +47,41 @@ const homePage = await sanityClient.fetch<HomePage>(homePageQuery);
     widths={[300, 600]}
     sizes="(max-width: 300px) 100vw, 300px"
   />
-  <Image src={cheese} alt="Bird's Eye Farm cheese" class="galleryItem" widths={[300, 600]} sizes="(max-width: 300px) 100vw, 300px" />
-  <Image src={garden} alt="The garden in all it's glory" class="galleryItem" widths={[300, 600]} sizes="(max-width: 300px) 100vw, 300px" />
-  <Image src={bia} alt="Bia in hand" class="galleryItem" widths={[300, 600]} sizes="(max-width: 300px) 100vw, 300px" />
-  <Image src={emma} alt="Emma in the flower patch " class="galleryItem" widths={[300, 600]} sizes="(max-width: 300px) 100vw, 300px" />
-  <Image src={laila} alt="Laila picking vegetables" class="galleryItem" widths={[300, 600]} sizes="(max-width: 300px) 100vw, 300px" />
+  <Image
+    src={cheese}
+    alt="Bird's Eye Farm cheese"
+    class="galleryItem"
+    widths={[300, 600]}
+    sizes="(max-width: 300px) 100vw, 300px"
+  />
+  <Image
+    src={garden}
+    alt="The garden in all it's glory"
+    class="galleryItem"
+    widths={[300, 600]}
+    sizes="(max-width: 300px) 100vw, 300px"
+  />
+  <Image
+    src={bia}
+    alt="Bia in hand"
+    class="galleryItem"
+    widths={[300, 600]}
+    sizes="(max-width: 300px) 100vw, 300px"
+  />
+  <Image
+    src={emma}
+    alt="Emma in the flower patch "
+    class="galleryItem"
+    widths={[300, 600]}
+    sizes="(max-width: 300px) 100vw, 300px"
+  />
+  <Image
+    src={laila}
+    alt="Laila picking vegetables"
+    class="galleryItem"
+    widths={[300, 600]}
+    sizes="(max-width: 300px) 100vw, 300px"
+  />
   <Image
     src={flock}
     alt="The flock"

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -1,13 +1,19 @@
 ---
-import { Image } from 'astro:assets';
-import SectionContainer from '../SectionContainer.astro';
-import logo from '../../images/logo-large.png';
-import homeBackground from '../../images/home.jpg';
+import { Image } from 'astro:assets'
+import SectionContainer from '../SectionContainer.astro'
+import logo from '../../images/logo-large.png'
+import homeBackground from '../../images/home.jpg'
 ---
 
 <SectionContainer className="heroContainer">
   <div class="bgi" style={`background-image: url(${homeBackground.src})`}></div>
-  <Image src={logo} alt="Bird's Eye Farm" class="logo" widths={[400, 800]} sizes="(max-width: 400px) 100vw, 400px" />
+  <Image
+    src={logo}
+    alt="Bird's Eye Farm"
+    class="logo"
+    widths={[400, 800]}
+    sizes="(max-width: 400px) 100vw, 400px"
+  />
 </SectionContainer>
 
 <style>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,4 +1,4 @@
-import { defineCollection, z } from 'astro:content';
+import { defineCollection, z } from 'astro:content'
 
 const goatsCollection = defineCollection({
   type: 'data',
@@ -13,42 +13,56 @@ const goatsCollection = defineCollection({
     sire: z.object({
       name: z.string(),
       link: z.string(),
-      sire: z.object({
-        name: z.string(),
-        link: z.string().optional()
-      }).optional(),
-      dam: z.object({
-        name: z.string(),
-        link: z.string().optional()
-      }).optional()
+      sire: z
+        .object({
+          name: z.string(),
+          link: z.string().optional(),
+        })
+        .optional(),
+      dam: z
+        .object({
+          name: z.string(),
+          link: z.string().optional(),
+        })
+        .optional(),
     }),
     dam: z.object({
       name: z.string(),
       link: z.string(),
-      sire: z.object({
-        name: z.string(),
-        link: z.string().optional()
-      }).optional(),
-      dam: z.object({
-        name: z.string(),
-        link: z.string().optional()
-      }).optional()
+      sire: z
+        .object({
+          name: z.string(),
+          link: z.string().optional(),
+        })
+        .optional(),
+      dam: z
+        .object({
+          name: z.string(),
+          link: z.string().optional(),
+        })
+        .optional(),
     }),
-    mate: z.object({
-      name: z.string(),
-      slug: z.string(),
-      link: z.string()
-    }).optional(),
+    mate: z
+      .object({
+        name: z.string(),
+        slug: z.string(),
+        link: z.string(),
+      })
+      .optional(),
     copy: z.array(z.string()).default([]),
     notes: z.array(z.string()).default([]),
     prices: z.array(z.string()).default([]),
-    images: z.array(z.object({
-      filename: z.string(),
-      alt: z.string()
-    })).optional()
-  })
-});
+    images: z
+      .array(
+        z.object({
+          filename: z.string(),
+          alt: z.string(),
+        })
+      )
+      .optional(),
+  }),
+})
 
 export const collections = {
-  goats: goatsCollection
-};
+  goats: goatsCollection,
+}

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,22 +1,22 @@
 ---
-import { ViewTransitions } from 'astro:transitions';
-import Header from '../components/Header.astro';
-import '../styles/layout.css';
+import { ViewTransitions } from 'astro:transitions'
+import Header from '../components/Header.astro'
+import '../styles/layout.css'
 
 interface Props {
-  title?: string;
-  description?: string;
+  title?: string
+  description?: string
 }
 
 const {
   title = "Bird's Eye Farm",
-  description = "Farmstead lifestyle. Nigerian Dwarf goats, chickens, bees and Angora rabbits in Yamhill County, Oregon."
-} = Astro.props;
+  description = 'Farmstead lifestyle. Nigerian Dwarf goats, chickens, bees and Angora rabbits in Yamhill County, Oregon.',
+} = Astro.props
 
-const currentYear = new Date().getFullYear();
+const currentYear = new Date().getFullYear()
 ---
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -36,7 +36,10 @@ const currentYear = new Date().getFullYear();
     <!-- Google Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&family=Amatic+SC:wght@400;700&family=Josefin+Slab:wght@400;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;700&family=Amatic+SC:wght@400;700&family=Josefin+Slab:wght@400;700&display=swap"
+      rel="stylesheet"
+    />
 
     <ViewTransitions />
     <title>{title}</title>
@@ -47,9 +50,17 @@ const currentYear = new Date().getFullYear();
       <main class="main-content">
         <slot />
         <footer class="footer">
-          <img src="/andda-logo.png" alt="ANDDA member" style="height: 50px; margin-right: 10px;" />
+          <img
+            src="/andda-logo.png"
+            alt="ANDDA member"
+            style="height: 50px; margin-right: 10px;"
+          />
           © {currentYear} Bird's Eye Farm | Carlton, OR
-          <img src="/adga-logo.avif" alt="ADGA member" style="height: 50px; margin-left: 10px;" />
+          <img
+            src="/adga-logo.avif"
+            alt="ADGA member"
+            style="height: 50px; margin-left: 10px;"
+          />
         </footer>
       </main>
     </div>

--- a/src/lib/portableText.ts
+++ b/src/lib/portableText.ts
@@ -1,19 +1,19 @@
-import { toHTML } from '@portabletext/to-html';
-import type { PortableTextBlock } from '@portabletext/types';
+import { toHTML } from '@portabletext/to-html'
+import type { PortableTextBlock } from '@portabletext/types'
 
 export function portableTextToHtml(blocks: PortableTextBlock[]): string {
   if (!blocks || !Array.isArray(blocks)) {
-    return '';
+    return ''
   }
 
   return toHTML(blocks, {
     components: {
       marks: {
         link: ({ children, value }) => {
-          const href = value?.href || '';
-          return `<a href="${href}" target="_blank" rel="noopener noreferrer">${children}</a>`;
+          const href = value?.href || ''
+          return `<a href="${href}" target="_blank" rel="noopener noreferrer">${children}</a>`
         },
       },
     },
-  });
+  })
 }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -21,7 +21,7 @@ export const allGoatsQuery = `*[_type == "goat"] | order(displayOrder asc) {
     },
     alt
   }
-}`;
+}`
 
 export const goatBySlugQuery = `*[_type == "goat" && slug.current == $slug][0] {
   _id,
@@ -45,7 +45,7 @@ export const goatBySlugQuery = `*[_type == "goat" && slug.current == $slug][0] {
     },
     alt
   }
-}`;
+}`
 
 export const homePageQuery = `*[_type == "homePage"][0] {
   _id,
@@ -79,13 +79,13 @@ export const homePageQuery = `*[_type == "homePage"][0] {
   },
   instagramUrl,
   contactHeading
-}`;
+}`
 
 export const goatsPageQuery = `*[_type == "goatsPage"][0] {
   _id,
   title,
   introText
-}`;
+}`
 
 export const kiddingScheduleQuery = `*[_type == "goat" && defined(kiddingDate)] | order(kiddingScheduleOrder asc) {
   _id,
@@ -119,4 +119,4 @@ export const kiddingScheduleQuery = `*[_type == "goat" && defined(kiddingDate)] 
       alt
     }
   }
-}`;
+}`

--- a/src/lib/sanity.ts
+++ b/src/lib/sanity.ts
@@ -1,16 +1,16 @@
-import { createClient } from '@sanity/client';
-import imageUrlBuilder from '@sanity/image-url';
-import type { SanityImageSource } from '@sanity/image-url';
+import { createClient } from '@sanity/client'
+import imageUrlBuilder from '@sanity/image-url'
+import type { SanityImageSource } from '@sanity/image-url'
 
 export const sanityClient = createClient({
   projectId: import.meta.env.PUBLIC_SANITY_STUDIO_PROJECT_ID,
   dataset: import.meta.env.PUBLIC_SANITY_STUDIO_DATASET,
   useCdn: import.meta.env.PROD, // Use CDN in production, bypass in development
   apiVersion: '2024-01-01',
-});
+})
 
-const builder = imageUrlBuilder(sanityClient);
+const builder = imageUrlBuilder(sanityClient)
 
 export function urlFor(source: SanityImageSource) {
-  return builder.image(source);
+  return builder.image(source)
 }

--- a/src/pages/deliveries/index.astro
+++ b/src/pages/deliveries/index.astro
@@ -1,6 +1,6 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import Deliveries from '../../components/sections/Deliveries.astro';
+import Layout from '../../layouts/Layout.astro'
+import Deliveries from '../../components/sections/Deliveries.astro'
 ---
 
 <Layout

--- a/src/pages/goats/[slug].astro
+++ b/src/pages/goats/[slug].astro
@@ -1,35 +1,36 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import SectionContainer from '../../components/SectionContainer.astro';
-import SectionTitle from '../../components/SectionTitle.astro';
-import GoatBio from '../../components/GoatBio.astro';
-import { sanityClient } from '../../lib/sanity';
-import { allGoatsQuery } from '../../lib/queries';
-import type { Goat } from '../../types/sanity';
+import Layout from '../../layouts/Layout.astro'
+import SectionContainer from '../../components/SectionContainer.astro'
+import SectionTitle from '../../components/SectionTitle.astro'
+import GoatBio from '../../components/GoatBio.astro'
+import { sanityClient } from '../../lib/sanity'
+import { allGoatsQuery } from '../../lib/queries'
+import type { Goat } from '../../types/sanity'
 
 export async function getStaticPaths() {
-  const goats = await sanityClient.fetch<Goat[]>(allGoatsQuery);
+  const goats = await sanityClient.fetch<Goat[]>(allGoatsQuery)
 
   return goats.map((goat) => ({
     params: { slug: goat.slug },
-    props: { goat }
-  }));
+    props: { goat },
+  }))
 }
 
 interface Props {
-  goat: Goat;
+  goat: Goat
 }
 
-const { goat } = Astro.props;
+const { goat } = Astro.props
 
 // Transform Sanity images to match expected format
-const images = goat.images?.map((img) => ({
-  src: img.asset.url,
-  alt: img.alt || goat.name,
-})) || [];
+const images =
+  goat.images?.map((img) => ({
+    src: img.asset.url,
+    alt: img.alt || goat.name,
+  })) || []
 
 // For Sanity, copy comes as plain text array - no image processing needed
-const processedCopy = goat.copy || [];
+const processedCopy = goat.copy || []
 ---
 
 <Layout

--- a/src/pages/goats/index.astro
+++ b/src/pages/goats/index.astro
@@ -1,22 +1,23 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import SectionContainer from '../../components/SectionContainer.astro';
-import Info from '../../components/Info.astro';
-import GoatBio from '../../components/GoatBio.astro';
-import { sanityClient } from '../../lib/sanity';
-import { allGoatsQuery, goatsPageQuery } from '../../lib/queries';
-import { portableTextToHtml } from '../../lib/portableText';
-import type { Goat, GoatsPage } from '../../types/sanity';
+import Layout from '../../layouts/Layout.astro'
+import SectionContainer from '../../components/SectionContainer.astro'
+import Info from '../../components/Info.astro'
+import GoatBio from '../../components/GoatBio.astro'
+import { sanityClient } from '../../lib/sanity'
+import { allGoatsQuery, goatsPageQuery } from '../../lib/queries'
+import { portableTextToHtml } from '../../lib/portableText'
+import type { Goat, GoatsPage } from '../../types/sanity'
 
-const goats = await sanityClient.fetch<Goat[]>(allGoatsQuery);
-const goatsPage = await sanityClient.fetch<GoatsPage>(goatsPageQuery);
+const goats = await sanityClient.fetch<Goat[]>(allGoatsQuery)
+const goatsPage = await sanityClient.fetch<GoatsPage>(goatsPageQuery)
 
 // Transform Sanity images to match expected format
 const goatsWithImages = goats.map((goat) => {
-  const images = goat.images?.map((img) => ({
-    src: img.asset.url,
-    alt: img.alt || goat.name,
-  })) || [];
+  const images =
+    goat.images?.map((img) => ({
+      src: img.asset.url,
+      alt: img.alt || goat.name,
+    })) || []
 
   return {
     ...goat,
@@ -28,9 +29,9 @@ const goatsWithImages = goats.map((goat) => {
       date: goat.date,
       sire: goat.sire,
       dam: goat.dam,
-    }
-  };
-});
+    },
+  }
+})
 ---
 
 <Layout title="Nigerian Dwarf Goats">
@@ -39,19 +40,21 @@ const goatsWithImages = goats.map((goat) => {
       <Fragment set:html={portableTextToHtml(goatsPage?.introText || [])} />
     </Info>
 
-    {goatsWithImages.map((goat) => (
-      <GoatBio
-        images={goat.images}
-        name={goat.data.name}
-        slug={goat.data.slug}
-        adgaPedigree={goat.data.adgaPedigree}
-        date={goat.data.date}
-        sire={goat.data.sire}
-        dam={goat.data.dam}
-        withTitle={true}
-        showCopy={false}
-      />
-    ))}
+    {
+      goatsWithImages.map((goat) => (
+        <GoatBio
+          images={goat.images}
+          name={goat.data.name}
+          slug={goat.data.slug}
+          adgaPedigree={goat.data.adgaPedigree}
+          date={goat.data.date}
+          sire={goat.data.sire}
+          dam={goat.data.dam}
+          withTitle={true}
+          showCopy={false}
+        />
+      ))
+    }
   </SectionContainer>
 </Layout>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,8 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Hero from '../components/sections/Hero.astro';
-import Gallery from '../components/sections/Gallery.astro';
-import Contact from '../components/sections/Contact.astro';
+import Layout from '../layouts/Layout.astro'
+import Hero from '../components/sections/Hero.astro'
+import Gallery from '../components/sections/Gallery.astro'
+import Contact from '../components/sections/Contact.astro'
 ---
 
 <Layout>

--- a/src/pages/kidding-schedule/index.astro
+++ b/src/pages/kidding-schedule/index.astro
@@ -1,23 +1,27 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import KiddingSchedule from '../../components/KiddingSchedule.astro';
-import { sanityClient } from '../../lib/sanity';
-import { kiddingScheduleQuery } from '../../lib/queries';
-import type { Goat } from '../../types/sanity';
+import Layout from '../../layouts/Layout.astro'
+import KiddingSchedule from '../../components/KiddingSchedule.astro'
+import { sanityClient } from '../../lib/sanity'
+import { kiddingScheduleQuery } from '../../lib/queries'
+import type { Goat } from '../../types/sanity'
 
-const goats = await sanityClient.fetch<Goat[]>(kiddingScheduleQuery);
+const goats = await sanityClient.fetch<Goat[]>(kiddingScheduleQuery)
 
 // Transform Sanity data to match component expectations
 const sortedGoatsWithImages = goats.map((goat) => {
-  const profileImage = goat.images?.[0] ? {
-    src: goat.images[0].asset.url,
-    alt: goat.images[0].alt || goat.name
-  } : undefined;
+  const profileImage = goat.images?.[0]
+    ? {
+        src: goat.images[0].asset.url,
+        alt: goat.images[0].alt || goat.name,
+      }
+    : undefined
 
-  const mateImage = goat.mateSire?.image ? {
-    src: goat.mateSire.image.asset.url,
-    alt: goat.mateSire.image.alt || goat.mateSire.name
-  } : undefined;
+  const mateImage = goat.mateSire?.image
+    ? {
+        src: goat.mateSire.image.asset.url,
+        alt: goat.mateSire.image.alt || goat.mateSire.name,
+      }
+    : undefined
 
   return {
     id: goat.slug,
@@ -30,16 +34,16 @@ const sortedGoatsWithImages = goats.map((goat) => {
       notes: goat.notes,
       prices: goat.prices,
       adgaPedigree: goat.adgaPedigree,
-      pedigree: goat.pedigree
+      pedigree: goat.pedigree,
     },
     profileImage,
-    mateImage
-  };
-});
+    mateImage,
+  }
+})
 ---
 
 <Layout
-  title='2026 Kidding Schedule'
+  title="2026 Kidding Schedule"
   description="Bird's Eye Farm 2026 Kidding Schedule"
 >
   <KiddingSchedule goats={sortedGoatsWithImages} />

--- a/src/test-glob-debug.ts
+++ b/src/test-glob-debug.ts
@@ -1,10 +1,15 @@
 const images = import.meta.glob<{ default: any }>(
   '/src/images/**/*.{jpg,jpeg,png,webp,avif,HEIC}'
-);
+)
 
-console.log('All glob keys:');
-Object.keys(images).sort().forEach(key => {
-  if (key.includes('birds-eye-farm-ina-may') || key.includes('diji-farm-cacao-nib')) {
-    console.log(key);
-  }
-});
+console.log('All glob keys:')
+Object.keys(images)
+  .sort()
+  .forEach((key) => {
+    if (
+      key.includes('birds-eye-farm-ina-may') ||
+      key.includes('diji-farm-cacao-nib')
+    ) {
+      console.log(key)
+    }
+  })

--- a/src/types/sanity.ts
+++ b/src/types/sanity.ts
@@ -1,83 +1,83 @@
 // Sanity types for type-safe queries
 
 export interface SanityImageAsset {
-  _id: string;
-  url: string;
+  _id: string
+  url: string
 }
 
 export interface SanityImage {
-  asset: SanityImageAsset;
-  alt?: string;
+  asset: SanityImageAsset
+  alt?: string
 }
 
 export interface SireOrDam {
-  name: string;
-  link: string; // Required: All sire/dam entries have links
-  sire?: SireOrDam;
-  dam?: SireOrDam;
+  name: string
+  link: string // Required: All sire/dam entries have links
+  sire?: SireOrDam
+  dam?: SireOrDam
 }
 
 export interface Mate {
-  name: string;
-  slug: string;
-  link: string;
+  name: string
+  slug: string
+  link: string
 }
 
 export interface Sire {
-  name: string;
-  slug: string;
-  link: string;
-  image: SanityImage;
+  name: string
+  slug: string
+  link: string
+  image: SanityImage
 }
 
 export interface Goat {
-  _id: string;
-  name: string;
-  aka: string;
-  slug: string;
-  date: string; // Required: All goats have a date of birth
-  adgaPedigree: string; // Required: All goats have ADGA pedigree link
-  sire: SireOrDam; // Required: All goats have sire
-  dam: SireOrDam; // Required: All goats have dam
-  pedigree?: string;
-  kiddingDate?: string;
-  mate?: Mate;
-  copy?: string[];
-  notes?: string[];
-  prices?: string[];
-  images?: SanityImage[];
-  displayOrder?: number;
-  kiddingScheduleOrder?: number;
-  mateSire?: Sire;
+  _id: string
+  name: string
+  aka: string
+  slug: string
+  date: string // Required: All goats have a date of birth
+  adgaPedigree: string // Required: All goats have ADGA pedigree link
+  sire: SireOrDam // Required: All goats have sire
+  dam: SireOrDam // Required: All goats have dam
+  pedigree?: string
+  kiddingDate?: string
+  mate?: Mate
+  copy?: string[]
+  notes?: string[]
+  prices?: string[]
+  images?: SanityImage[]
+  displayOrder?: number
+  kiddingScheduleOrder?: number
+  mateSire?: Sire
 }
 
 export interface GoatsPage {
-  _id: string;
-  title: string;
-  introText?: PortableTextBlock[];
+  _id: string
+  title: string
+  introText?: PortableTextBlock[]
 }
 
 export interface HomePage {
-  _id: string;
-  heroLogo?: SanityImage;
-  heroBackground?: SanityImage;
-  welcomeTitle?: string;
-  welcomeText?: PortableTextBlock[];
-  familyPhoto?: SanityImage;
-  galleryImages?: SanityImage[];
-  instagramUrl?: string;
-  contactHeading?: string;
+  _id: string
+  heroLogo?: SanityImage
+  heroBackground?: SanityImage
+  welcomeTitle?: string
+  welcomeText?: PortableTextBlock[]
+  familyPhoto?: SanityImage
+  galleryImages?: SanityImage[]
+  instagramUrl?: string
+  contactHeading?: string
 }
 
 // Portable Text types (simplified)
 export interface PortableTextBlock {
-  _type: 'block';
-  style?: string;
-  children: PortableTextSpan[];
+  _type: 'block'
+  style?: string
+  children: PortableTextSpan[]
 }
 
 export interface PortableTextSpan {
-  _type: 'span';
-  text: string;
-  marks?: string[];
+  _type: 'span'
+  text: string
+  marks?: string[]
 }

--- a/src/utils/imageHelpers.ts
+++ b/src/utils/imageHelpers.ts
@@ -1,16 +1,16 @@
-import type { ImageMetadata } from 'astro';
+import type { ImageMetadata } from 'astro'
 
 interface GoatImage {
-  filename: string;
-  alt: string;
+  filename: string
+  alt: string
 }
 
 export async function getGoatImages(slug: string, imageList?: GoatImage[]) {
   const images = import.meta.glob<{ default: ImageMetadata }>(
     '/src/images/**/*.{jpg,jpeg,png,webp,avif,HEIC}'
-  );
+  )
 
-  const goatImages: Array<{ image: ImageMetadata; alt: string }> = [];
+  const goatImages: Array<{ image: ImageMetadata; alt: string }> = []
 
   if (imageList) {
     // Use the explicit image list from the JSON
@@ -21,50 +21,56 @@ export async function getGoatImages(slug: string, imageList?: GoatImage[]) {
           // Otherwise, it's relative to the goat's folder
           const imageKey = filename.startsWith('/')
             ? `/src/images${filename}`
-            : `/src/images/${slug}/${filename}`;
-          return images[imageKey] ? { imageKey, alt } : null;
+            : `/src/images/${slug}/${filename}`
+          return images[imageKey] ? { imageKey, alt } : null
         })
-        .filter((item): item is { imageKey: string; alt: string } => item !== null)
+        .filter(
+          (item): item is { imageKey: string; alt: string } => item !== null
+        )
         .map(async ({ imageKey, alt }) => ({
           image: (await images[imageKey]()).default,
-          alt
+          alt,
         }))
-    );
-    goatImages.push(...loadedImages);
+    )
+    goatImages.push(...loadedImages)
   }
 
-  return goatImages;
+  return goatImages
 }
 
 export async function getMateImage(slug: string) {
   const images = import.meta.glob<{ default: ImageMetadata }>(
     '/src/images/*.{jpg,jpeg,png,webp,avif}'
-  );
+  )
 
   // Try to find an image that matches the slug
   for (const key of Object.keys(images)) {
     if (key.toLowerCase().includes(slug.toLowerCase())) {
-      return (await images[key]()).default;
+      return (await images[key]()).default
     }
   }
 
-  return null;
+  return null
 }
 
 export async function getAllMateImages() {
   const images = import.meta.glob<{ default: ImageMetadata }>(
     '/src/images/*.{jpg,jpeg,png,webp,avif}'
-  );
+  )
 
-  const mateImages: Record<string, ImageMetadata> = {};
+  const mateImages: Record<string, ImageMetadata> = {}
 
   for (const [key, value] of Object.entries(images)) {
     // Extract filename without path and extension
-    const filename = key.split('/').pop()?.split('.')[0];
-    if (filename && !filename.includes('logo') && !filename.includes('skeeter')) {
-      mateImages[filename] = (await value()).default;
+    const filename = key.split('/').pop()?.split('.')[0]
+    if (
+      filename &&
+      !filename.includes('logo') &&
+      !filename.includes('skeeter')
+    ) {
+      mateImages[filename] = (await value()).default
     }
   }
 
-  return mateImages;
+  return mateImages
 }


### PR DESCRIPTION
## Summary
- New `.github/workflows/ci.yml` — runs format check → `astro check` → `astro build` on PRs and pushes to main, with concurrency cancellation so stale runs are dropped.
- Installs `prettier-plugin-astro` and adds an `.astro` parser override to `.prettierrc` so `.astro` files actually get formatted (they were being silently skipped before).
- Adds `format:check` script (non-mutating, for CI) alongside the existing `format` (write).
- Reformats all 24 source files to current Prettier config. **No behavior or design changes** — whitespace, quotes, and semicolons only.

This is the safety net for the upcoming refactors flagged in the recent code review (dead content pipeline removal, single image pipeline, etc.) so format drift doesn't muddy diffs and breakage is caught before Netlify deploys.

`PUBLIC_SANITY_STUDIO_PROJECT_ID` and `PUBLIC_SANITY_STUDIO_DATASET` are inlined in the workflow env block — they match the values already hardcoded in `astro.config.mjs` and embedded in the production JS bundle, so they aren't secrets. The only real secret (`SANITY_API_TOKEN`) is local-only for the sync script and doesn't affect production builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)