### PR TITLE
Make delivery form options configurable in Sanity

### DIFF
--- a/sanity/schemas/deliveriesPage.ts
+++ b/sanity/schemas/deliveriesPage.ts
@@ -1,0 +1,33 @@
+import { defineType, defineField } from 'sanity';
+
+export default defineType({
+  name: 'deliveriesPage',
+  title: 'Deliveries Page',
+  type: 'document',
+  fields: [
+    defineField({
+      name: 'options',
+      title: 'Delivery Options',
+      type: 'array',
+      of: [{ type: 'string' }],
+      description:
+        'Checkbox options shown on the deliveries form. Drag to reorder. The text here is also the value recorded in form submissions.',
+      initialValue: [
+        'Dozen-A-Week 🍳 Subscription ($24/month)',
+        'Now-and-Then Eggs ($8/doz)',
+        'Honey',
+        'Seasonal fruit & veggies',
+        'Other',
+      ],
+      validation: (Rule) => Rule.min(1),
+    }),
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: 'Deliveries Page',
+        subtitle: 'Delivery form options',
+      };
+    },
+  },
+});

--- a/sanity/schemas/index.ts
+++ b/sanity/schemas/index.ts
@@ -1,6 +1,7 @@
 import goat from './goat';
 import homePage from './homePage';
 import goatsPage from './goatsPage';
+import deliveriesPage from './deliveriesPage';
 import sire from './sire';
 
-export const schemas = [goat, sire, homePage, goatsPage];
+export const schemas = [goat, sire, homePage, goatsPage, deliveriesPage];

--- a/src/components/sections/Deliveries.astro
+++ b/src/components/sections/Deliveries.astro
@@ -2,6 +2,14 @@
 import SectionContainer from '../SectionContainer.astro'
 import SectionTitle from '../SectionTitle.astro'
 import Button from '../Button.astro'
+import { sanityClient } from '../../lib/sanity'
+import { deliveriesPageQuery } from '../../lib/queries'
+import type { DeliveriesPage } from '../../types/sanity'
+
+const deliveriesPage = await sanityClient.fetch<DeliveriesPage | null>(
+  deliveriesPageQuery
+)
+const options = deliveriesPage?.options ?? []
 ---
 
 <SectionContainer id="deliveries" className="container">
@@ -24,42 +32,14 @@ import Button from '../Button.astro'
     <fieldset class="options">
       <legend class="sr-only">Delivery options</legend>
 
-      <label class="checkbox">
-        <input
-          type="checkbox"
-          name="deliveryOptions"
-          value="Dozen-A-Week 🍳 Subscription ($24/month)"
-        />
-        <span>Dozen-A-Week 🍳 Subscription ($24/month)</span>
-      </label>
-
-      <label class="checkbox">
-        <input
-          type="checkbox"
-          name="deliveryOptions"
-          value="Now-and-Then Eggs ($8/doz)"
-        />
-        <span>Now-and-Then Eggs ($8/doz)</span>
-      </label>
-
-      <label class="checkbox">
-        <input type="checkbox" name="deliveryOptions" value="Honey" />
-        <span>Honey</span>
-      </label>
-
-      <label class="checkbox">
-        <input
-          type="checkbox"
-          name="deliveryOptions"
-          value="Seasonal fruit & veggies"
-        />
-        <span>Seasonal fruit &amp; veggies</span>
-      </label>
-
-      <label class="checkbox">
-        <input type="checkbox" name="deliveryOptions" value="Other" />
-        <span>Other</span>
-      </label>
+      {
+        options.map((option) => (
+          <label class="checkbox">
+            <input type="checkbox" name="deliveryOptions" value={option} />
+            <span>{option}</span>
+          </label>
+        ))
+      }
     </fieldset>
 
     <input

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -87,6 +87,11 @@ export const goatsPageQuery = `*[_type == "goatsPage"][0] {
   introText
 }`
 
+export const deliveriesPageQuery = `*[_type == "deliveriesPage"][0] {
+  _id,
+  options
+}`
+
 export const kiddingScheduleQuery = `*[_type == "goat" && defined(kiddingDate)] | order(kiddingScheduleOrder asc) {
   _id,
   name,

--- a/src/types/sanity.ts
+++ b/src/types/sanity.ts
@@ -57,6 +57,11 @@ export interface GoatsPage {
   introText?: PortableTextBlock[]
 }
 
+export interface DeliveriesPage {
+  _id: string
+  options?: string[]
+}
+
 export interface HomePage {
   _id: string
   heroLogo?: SanityImage


### PR DESCRIPTION
## Summary
- New `deliveriesPage` Sanity singleton schema with an `options: string[]` field. `initialValue` pre-populates the current 5 options so seeding is one click in Studio.
- `src/components/sections/Deliveries.astro` now fetches `deliveriesPage` and renders checkboxes from the options array. The hardcoded fieldset is gone.
- New `deliveriesPageQuery` in `src/lib/queries.ts` and matching `DeliveriesPage` type in `src/types/sanity.ts`.

The submitted Netlify form value is the option label itself — same as before, so submission emails stay readable. Editors can add, remove, rename, or drag-reorder options in Sanity Studio; the next build picks them up.

## Required step before deploying to production
Until a `deliveriesPage` document exists in Sanity, the form renders with **no checkboxes** (fallback is graceful — the rest of the form still works). To seed it:

1. Open Sanity Studio
2. Create a new "Deliveries Page" document
3. The 5 current options will be pre-populated via `initialValue`
4. Publish

Once published, the next Netlify build will render the checkboxes. After that, `deploys are decoupled from option changes — admins can edit options in Studio without a code change (though they will need to trigger a rebuild for the new options to appear).

## Branch base
Stacked on top of #67 (CI / format) so this branch includes the Prettier reformat. Once #67 merges, this PR will rebase cleanly onto main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)